### PR TITLE
claimrole: send `role grant transaction has been broadcasted` instead of `role successfully claimed`

### DIFF
--- a/api/v1/claimRole/claimrole.go
+++ b/api/v1/claimRole/claimrole.go
@@ -90,7 +90,7 @@ func postClaimRole(c *gin.Context) {
 	payload := ClaimRolePayload{
 		TransactionHash: transactionHash,
 	}
-	httphelper.SuccessResponse(c, "Role successfully claimed", payload)
+	httphelper.SuccessResponse(c, "role grant transaction has been broadcasted", payload)
 
 }
 


### PR DESCRIPTION
fix #23